### PR TITLE
Add support for block actions

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -51,6 +51,7 @@
       - [server.setTime(time)](#serversettimetime)
       - [server.setTickInterval(ticksPerSecond)](#serversettickintervaltickspersecond)
       - [server.setBlock(world, position, blockType, blockData)](#serversetblockworld-position-blocktype-blockdata)
+      - [server.setBlockAction(world, position, actionId, actionParam)](#serversetblockactionworld-position-actionid-actionparam)
       - [server.playSound(sound, world, position, opt)](#serverplaysoundsound-world-position-opt)
       - [server.playNoteBlock(world, position, pitch)](#serverplaynoteblockworld-position-pitch)
       - [server.getNote(note)](#servergetnotenote)
@@ -121,6 +122,7 @@
       - ["command"](#command)
       - ["punch"](#punch)
       - ["sendBlock"](#sendblock)
+      - ["sendBlockAction"](#sendblockaction)
       - ["sendChunk"](#sendchunk)
       - ["dig"](#dig)
       - ["dug"](#dug)
@@ -138,10 +140,12 @@
       - [player.chat(message)](#playerchatmessage)
       - [player.changeBlock(position,blockType,blockData)](#playerchangeblockpositionblocktypeblockdata)
       - [player.sendBlock(position,blockType,blockData)](#playersendblockpositionblocktypeblockdata)
+      - [player.sendBlockAction(position,actionId,actionParam,blockType)](#playersendblockactionpositionactionidactionparamblocktype)
       - [player.sendInitialPosition()](#playersendinitialposition)
       - [player.setGameMode(gameMode)](#playersetgamemodegamemode)
       - [player.handleCommand(command)](#playerhandlecommandcommand)
       - [player.setBlock(position,blockType,blockData)](#playersetblockpositionblocktypeblockdata)
+      - [player.setBlockAction(position,actionId,actionParam)](#playersetblockactionpositionactionidactionparam)
       - [player.updateHealth(health)](#playerupdatehealthhealth)
       - [player.changeWorld(world, opt)](#playerchangeworldworld-opt)
       - [player.spawnAPlayer(spawnedPlayer)](#playerspawnaplayerspawnedplayer)
@@ -380,6 +384,10 @@ Use `server.stopTickInterval()` if you want but this method already calls that a
 #### server.setBlock(world, position, blockType, blockData)
 
 Saves block in world and sends block update to all players of the same world.
+
+#### server.setBlockAction(world, position, actionId, actionParam)
+
+Sends a block action to all players of the same world.
 
 #### server.playSound(sound, world, position, opt)
 
@@ -794,6 +802,20 @@ Default: Send block change to player.
 
 Cancelled: Nothing
 
+#### "sendBlockAction"
+
+Emitted when sending a block action to a player. This is separate for every player, cancelling this for one player will prevent the action from happening.
+- position: Position of the block
+- id: ID of the block
+- actionId: Action ID, dependent on the block.
+- actionParam: The parameters depend on the block.
+
+All block action IDs and parameters are listed [here](https://wiki.vg/Block_Actions).
+
+Default: Send block action to player.
+
+Cancelled: Nothing
+
 #### "sendChunk"
 
 Emitted when sending a chunk to a player (loading it in)
@@ -936,6 +958,15 @@ change the block at position `position` to `blockType` and `blockData`
 
 this will not make any changes on the server's world and only sends it to the user as a "fake" or "local" block
 
+#### player.sendBlockAction(position,actionId,actionParam,blockType)
+
+Set the block action at position `position` to `actionId` and `actionParam`.
+
+``blockType`` is only required when the block at the location is a fake block. 
+This will only be caused by using ``player.sendBlock``.
+
+This will not make any changes to the server's world and only sends it to the user as a local action.
+
 #### player.sendInitialPosition()
 
 send its initial position to the player
@@ -951,6 +982,12 @@ handle `command`
 #### player.setBlock(position,blockType,blockData)
 
 Saves block in world and sends block update to all players of the same world.
+
+#### player.setBlockAction(position,actionId,actionParam)
+
+Sets a block action and sends the block action to all players in the same world.
+
+This will not make any changes to the server's world
 
 #### player.updateHealth(health)
 

--- a/src/lib/plugins/blocks.js
+++ b/src/lib/plugins/blocks.js
@@ -38,8 +38,8 @@ module.exports.player = function (player, serv) {
     }, ({ position, blockType, actionId, actionParam }) => {
       player._client.write('block_action', {
         location: position,
-        actionId: actionId,
-        actionParam: actionParam,
+        byte1: actionId,
+        byte2: actionParam,
         blockId: blockType
       })
     })

--- a/src/lib/plugins/blocks.js
+++ b/src/lib/plugins/blocks.js
@@ -24,10 +24,10 @@ module.exports.player = function (player, serv) {
 
   player.setBlock = (position, blockType, blockData) => serv.setBlock(player.world, position, blockType, blockData)
 
-  player.sendBlockAction = (position, actionId, actionParam, blockType) => {
+  player.sendBlockAction = async (position, actionId, actionParam, blockType) => {
     if (!blockType) {
       const location = new Vec3(position.x, position.y, position.z)
-      blockType = player.world.getBlockType(location)
+      blockType = await player.world.getBlockType(location)
     }
 
     player.behavior('sendBlockAction', {
@@ -61,6 +61,21 @@ module.exports.player = function (player, serv) {
       let res = params.slice(1, 4)
       res = res.map((val, i) => serv.posFromString(val, player.position[['x', 'y', 'z'][i]]))
       player.setBlock(new Vec3(res[0], res[1], res[2]).floored(), params[4], params[5] || 0)
+    }
+  })
+
+  player.commands.add({
+    base: 'setblockaction',
+    info: 'set a block action',
+    usage: '/setblockaction <x> <y> <z> <actionId> <actionParam>',
+    op: true,
+    parse (str) {
+      const results = str.match(/^(-?[0-9]+) (-?[0-9]+) (-?[0-9]+) (-?[0-9]+) (-?[0-9]+)?/)
+      if (!results) return false
+      return results
+    },
+    action (params) {
+      player.setBlockAction(new Vec3(params[1], params[2], params[3]).floored(), params[4], params[5])
     }
   })
 }

--- a/src/lib/plugins/blocks.js
+++ b/src/lib/plugins/blocks.js
@@ -24,6 +24,29 @@ module.exports.player = function (player, serv) {
 
   player.setBlock = (position, blockType, blockData) => serv.setBlock(player.world, position, blockType, blockData)
 
+  player.sendBlockAction = (position, actionId, actionParam, blockType) => {
+    if (!blockType) {
+      const location = new Vec3(position.x, position.y, position.z)
+      blockType = player.world.getBlockType(location)
+    }
+
+    player.behavior('sendBlockAction', {
+      position: position,
+      blockType: blockType,
+      actionId: actionId,
+      actionParam: actionParam
+    }, ({ position, blockType, actionId, actionParam }) => {
+      player._client.write('block_action', {
+        location: position,
+        actionId: actionId,
+        actionParam: actionParam,
+        blockId: blockType
+      })
+    })
+  }
+
+  player.setBlockAction = (position, byte1, byte2) => serv.setBlockAction(player.world, position, byte1, byte2)
+
   player.commands.add({
     base: 'setblock',
     info: 'set a block at a position',

--- a/src/lib/plugins/blocks.js
+++ b/src/lib/plugins/blocks.js
@@ -45,7 +45,7 @@ module.exports.player = function (player, serv) {
     })
   }
 
-  player.setBlockAction = (position, byte1, byte2) => serv.setBlockAction(player.world, position, byte1, byte2)
+  player.setBlockAction = (position, actionId, actionParam) => serv.setBlockAction(player.world, position, actionId, actionParam)
 
   player.commands.add({
     base: 'setblock',

--- a/src/lib/plugins/world.js
+++ b/src/lib/plugins/world.js
@@ -1,4 +1,5 @@
 const spiralloop = require('spiralloop')
+const Vec3 = require('vec3').Vec3
 
 const generations = require('flying-squid').generations
 const { promisify } = require('util')
@@ -65,9 +66,12 @@ module.exports.server = async function (serv, { version, worldFolder, generation
   }
 
   serv.setBlockAction = async (world, position, actionId, actionParam) => {
+    const location = new Vec3(position.x, position.y, position.z)
+    const blockType = await world.getBlockType(location)
+
     serv.players
       .filter(p => p.world === world)
-      .forEach(player => player.sendBlockAction(position, actionId, actionParam))
+      .forEach(player => player.sendBlockAction(position, actionId, actionParam, blockType))
   }
 
   serv.reloadChunks = (world, chunks) => {

--- a/src/lib/plugins/world.js
+++ b/src/lib/plugins/world.js
@@ -64,6 +64,12 @@ module.exports.server = async function (serv, { version, worldFolder, generation
     await world.setBlockData(position, blockData)
   }
 
+  serv.setBlockAction = async (world, position, actionId, actionParam) => {
+    serv.players
+      .filter(p => p.world === world)
+      .forEach(player => player.sendBlockAction(position, actionId, actionParam))
+  }
+
   serv.reloadChunks = (world, chunks) => {
     serv.players
       .filter(player => player.world === world)


### PR DESCRIPTION
This will allow a plugin to make use of block actions. They are required to visually open chests, pistons and more.

wiki.vg reference: https://wiki.vg/Block_Actions
minecraft-data reference: https://minecraft-data.prismarine.js.org/?d=protocol#toClient_block_action