### PR TITLE
Fix crash in /gamemode command

### DIFF
--- a/src/lib/plugins/players.js
+++ b/src/lib/plugins/players.js
@@ -24,8 +24,8 @@ module.exports.server = function (serv, { version }) {
       if (paramsSplit[0] === '') {
         return false
       }
-      if (!paramsSplit[0].match(/^([0-3])$/) && paramsSplit[0].match(/^([0-9]+)$/)) {
-        throw new UserError(`The number you have entered (${paramsSplit[0]}) is too big, it must be at most 3`)
+      if (!paramsSplit[0].match(/^([0-3])$/)) {
+        throw new UserError(`The gamemode you have entered (${paramsSplit[0]}) is not valid, it must be a number from 0-3`)
       }
       if (!paramsSplit[1]) {
         if (ctx.player) return paramsSplit[0].match(/^([0-3])$/)

--- a/src/lib/plugins/players.js
+++ b/src/lib/plugins/players.js
@@ -17,7 +17,7 @@ module.exports.server = function (serv, { version }) {
     base: 'gamemode',
     aliases: ['gm'],
     info: 'to change game mode',
-    usage: '/gamemode <0-3> [player]',
+    usage: '/gamemode <mode> [player]',
     op: true,
     parse (str, ctx) {
       var paramsSplit = str.split(' ')

--- a/src/lib/plugins/players.js
+++ b/src/lib/plugins/players.js
@@ -24,38 +24,39 @@ module.exports.server = function (serv, { version }) {
       if (paramsSplit[0] === '') {
         return false
       }
-      if (!paramsSplit[0].match(/^([0-3])$/)) {
-        throw new UserError(`The gamemode you have entered (${paramsSplit[0]}) is not valid, it must be a number from 0-3`)
+      if (!paramsSplit[0].match(/^(survival|creative|adventure|spectator)$/)) {
+        throw new UserError(`The gamemode you have entered (${paramsSplit[0]}) is not valid, it must be survival, creative, adventure, or spectator`)
       }
       if (!paramsSplit[1]) {
-        if (ctx.player) return paramsSplit[0].match(/^([0-3])$/)
+        if (ctx.player) return paramsSplit[0].match(/^(survival|creative|adventure|spectator)$/)
         else throw new UserError('Console cannot set gamemode itself')
       }
 
-      return str.match(/^([0-3]) (\w+)$/) || false
+      return str.match(/^(survival|creative|adventure|spectator) (\w+)$/) || false
       // return params || false
     },
     action (str, ctx) {
       var gamemodes = {
-        0: 'Survival',
-        1: 'Creative',
-        2: 'Adventure',
-        3: 'Spectator'
+        'survival': 0,
+        'creative': 1,
+        'adventure': 2,
+        'spectator': 3
       }
-      var mode = gamemodes[str[1]]
+      var gamemode = gamemodes[str[1]]
+      var mode = str[1]
       var plyr = serv.getPlayer(str[2])
       if (ctx.player) {
         if (str[2]) {
           if (plyr !== null) {
-            plyr.setGameMode(parseInt(str[1], 10))
+            plyr.setGameMode(gamemode)
             return `Set ${str[2]}'s game mode to ${mode} Mode`
           } else {
             throw new UserError(`Player '${str[2]}' cannot be found`)
           }
-        } else ctx.player.setGameMode(parseInt(str[1], 10))
+        } else ctx.player.setGameMode(gamemode)
       } else {
         if (plyr !== null) {
-          plyr.setGameMode(parseInt(str[1], 10))
+          plyr.setGameMode(gamemode)
           return `Set ${str[2]}'s game mode to ${mode} Mode`
         } else {
           throw new UserError(`Player '${str[2]}' cannot be found`)

--- a/src/lib/plugins/players.js
+++ b/src/lib/plugins/players.js
@@ -40,9 +40,9 @@ module.exports.server = function (serv, { version }) {
         survival: 0,
         creative: 1,
         adventure: 2,
-        spectator: 3,
+        spectator: 3
       }
-      var gamemodesReverse = Object.assign({}, ...Object.entries(gamemodes).map(([k, v]) => ({[v]: k})))
+      var gamemodesReverse = Object.assign({}, ...Object.entries(gamemodes).map(([k, v]) => ({ [v]: k })))
       var gamemode = parseInt(str[1], 10) || gamemodes[str[1]]
       var mode = parseInt(str[1], 10) ? gamemodesReverse[parseInt(str[1], 10)] : str[1]
       var plyr = serv.getPlayer(str[2])

--- a/src/lib/plugins/players.js
+++ b/src/lib/plugins/players.js
@@ -24,15 +24,15 @@ module.exports.server = function (serv, { version }) {
       if (paramsSplit[0] === '') {
         return false
       }
-      if (!paramsSplit[0].match(/^(survival|creative|adventure|spectator)$/)) {
+      if (!paramsSplit[0].match(/^(survival|creative|adventure|spectator|[0-3])$/)) {
         throw new UserError(`The gamemode you have entered (${paramsSplit[0]}) is not valid, it must be survival, creative, adventure, or spectator`)
       }
       if (!paramsSplit[1]) {
-        if (ctx.player) return paramsSplit[0].match(/^(survival|creative|adventure|spectator)$/)
+        if (ctx.player) return paramsSplit[0].match(/^(survival|creative|adventure|spectator|[0-3])$/)
         else throw new UserError('Console cannot set gamemode itself')
       }
 
-      return str.match(/^(survival|creative|adventure|spectator) (\w+)$/) || false
+      return str.match(/^(survival|creative|adventure|spectator|[0-3]) (\w+)$/) || false
       // return params || false
     },
     action (str, ctx) {
@@ -40,10 +40,11 @@ module.exports.server = function (serv, { version }) {
         survival: 0,
         creative: 1,
         adventure: 2,
-        spectator: 3
+        spectator: 3,
       }
-      var gamemode = gamemodes[str[1]]
-      var mode = str[1]
+      var gamemodesReverse = Object.assign({}, ...Object.entries(gamemodes).map(([k, v]) => ({[v]: k})))
+      var gamemode = parseInt(str[1], 10) || gamemodes[str[1]]
+      var mode = parseInt(str[1], 10) ? gamemodesReverse[parseInt(str[1], 10)] : str[1]
       var plyr = serv.getPlayer(str[2])
       if (ctx.player) {
         if (str[2]) {

--- a/src/lib/plugins/players.js
+++ b/src/lib/plugins/players.js
@@ -25,7 +25,7 @@ module.exports.server = function (serv, { version }) {
         return false
       }
       if (!paramsSplit[0].match(/^(survival|creative|adventure|spectator|[0-3])$/)) {
-        throw new UserError(`The gamemode you have entered (${paramsSplit[0]}) is not valid, it must be survival, creative, adventure, or spectator`)
+        throw new UserError(`The gamemode you have entered (${paramsSplit[0]}) is not valid, it must be survival, creative, adventure, spectator, or a number from 0-3`)
       }
       if (!paramsSplit[1]) {
         if (ctx.player) return paramsSplit[0].match(/^(survival|creative|adventure|spectator|[0-3])$/)

--- a/src/lib/plugins/players.js
+++ b/src/lib/plugins/players.js
@@ -37,10 +37,10 @@ module.exports.server = function (serv, { version }) {
     },
     action (str, ctx) {
       var gamemodes = {
-        'survival': 0,
-        'creative': 1,
-        'adventure': 2,
-        'spectator': 3
+        survival: 0,
+        creative: 1,
+        adventure: 2,
+        spectator: 3
       }
       var gamemode = gamemodes[str[1]]
       var mode = str[1]

--- a/tools/dumpCodec.js
+++ b/tools/dumpCodec.js
@@ -31,7 +31,7 @@ download('1.16.1', MC_SERVER_JAR, (err) => {
     client.on('login', packet => {
       fs.writeFile('dimensionCodec.json', JSON.stringify(packet.dimensionCodec), (err) => {
         if (err) return console.error(err)
-        console.log("Dumped dimension codec successfully to dimensionCodec.json!")
+        console.log('Dumped dimension codec successfully to dimensionCodec.json!')
         client.end()
         wrap.stopServer(() => {
           wrap.deleteServerData(() => {})


### PR DESCRIPTION
Currently, if a player issues /gamemode with an invalid game mode which is not a number (Ex: "/gamemode survival") the server crashes. This PR modifies a check to validate that the inputted game mode is a number from 0-3.