### PR TITLE
Remove deprecated/heavy dependencies (request, request-promise) in favor of needle

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "minecraft-protocol": "^1.15.0",
     "mkdirp": "^0.5.1",
     "moment": "^2.10.6",
+    "needle": "^2.5.0",
     "node-gzip": "^1.1.2",
     "prismarine-chunk": "^1.20.1",
     "prismarine-entity": "^1.0.0",
@@ -48,8 +49,6 @@
     "random-seed": "^0.3.0",
     "range": "^0.0.3",
     "readline": "^1.3.0",
-    "request": "^2.83.0",
-    "request-promise": "^4.1.0",
     "spiralloop": "^1.0.2",
     "uuid-1345": "^1.0.1",
     "vec3": "^0.1.6"

--- a/src/lib/plugins/moderation.js
+++ b/src/lib/plugins/moderation.js
@@ -30,14 +30,16 @@ module.exports.server = function (serv, settings) {
   }
 
   serv.getUUIDFromUsername = async username => {
-    return needle('get', 'https://api.mojang.com/users/profiles/minecraft/' + username, { json: true })
+    return await new Promise((res) => {
+      needle('get', 'https://api.mojang.com/users/profiles/minecraft/' + username, { json: true })
       .then((response) => {
         if (!response.body) throw new Error('username not found')
         var idstr = response.body.id
         if (typeof idstr !== 'string') throw new Error('username not found')
-        return uuidInParts(idstr)
+        res(uuidInParts(idstr))
       })
       .catch(err => { throw err })
+    });
   }
 
   serv.banUsername = async (username, reason) => {

--- a/src/lib/plugins/moderation.js
+++ b/src/lib/plugins/moderation.js
@@ -32,9 +32,9 @@ module.exports.server = function (serv, settings) {
   serv.getUUIDFromUsername = async username => {
     return needle('get', 'https://api.mojang.com/users/profiles/minecraft/' + username, { json: true })
       .then((response) => {
-        if (!response.body) throw new Error('username not found');
-		var idstr = response.body.id;
-		if (typeof idstr != 'string') throw new Error('username not found');
+        if (!response.body) throw new Error('username not found')
+        var idstr = response.body.id
+        if (typeof idstr !== 'string') throw new Error('username not found')
         return uuidInParts(idstr)
       })
       .catch(err => { throw err })

--- a/src/lib/plugins/moderation.js
+++ b/src/lib/plugins/moderation.js
@@ -1,5 +1,5 @@
 const moment = require('moment')
-const rp = require('request-promise')
+const needle = require('needle')
 const UserError = require('flying-squid').UserError
 
 module.exports.server = function (serv, settings) {
@@ -30,10 +30,12 @@ module.exports.server = function (serv, settings) {
   }
 
   serv.getUUIDFromUsername = async username => {
-    return rp('https://api.mojang.com/users/profiles/minecraft/' + username)
-      .then((body) => {
-        if (!body) throw new Error('username not found')
-        return uuidInParts(JSON.parse(body).id)
+    return needle('get', 'https://api.mojang.com/users/profiles/minecraft/' + username, { json: true })
+      .then((response) => {
+        if (!response.body) throw new Error('username not found');
+		var idstr = response.body.id;
+		if (typeof idstr != 'string') throw new Error('username not found');
+        return uuidInParts(idstr)
       })
       .catch(err => { throw err })
   }

--- a/src/lib/plugins/moderation.js
+++ b/src/lib/plugins/moderation.js
@@ -30,16 +30,16 @@ module.exports.server = function (serv, settings) {
   }
 
   serv.getUUIDFromUsername = async username => {
-    return await new Promise((res) => {
+    return await new Promise((resolve, reject) => {
       needle('get', 'https://api.mojang.com/users/profiles/minecraft/' + username, { json: true })
-      .then((response) => {
-        if (!response.body) throw new Error('username not found')
-        var idstr = response.body.id
-        if (typeof idstr !== 'string') throw new Error('username not found')
-        res(uuidInParts(idstr))
-      })
-      .catch(err => { throw err })
-    });
+        .then((response) => {
+          if (!response.body) throw new Error('username not found')
+          var idstr = response.body.id
+          if (typeof idstr !== 'string') throw new Error('username not found')
+          resolve(uuidInParts(idstr))
+        })
+        .catch(err => { throw err })
+    })
   }
 
   serv.banUsername = async (username, reason) => {


### PR DESCRIPTION
Request and request-promise are both required for use in a single file. This is wasteful (and ill-advised, as the packages are deprecated), so I've decided to replace it with needle. You could probably also use the native http library, but I would argue importing needle is worth the trouble of adding error handling and json detection.