### PR TITLE
Refactor command.js to be clearer

### DIFF
--- a/src/lib/command.js
+++ b/src/lib/command.js
@@ -44,7 +44,6 @@ class Command {
       let output
       if (parsedResponse) output = await wantedCommand.params.action(parsedResponse, ctx)
       else output = await wantedCommand.params.action(resultsFound[1], ctx) // just give back the passed arg
-
       if (output) return '' + output
     } else {
       if (ctx.player) return 'Command not found'

--- a/src/lib/command.js
+++ b/src/lib/command.js
@@ -41,8 +41,9 @@ class Command {
           parsedResponse = passedArgs.match(customArgsParser)
         }
       }
-
-      const output = await wantedCommand.params.action(parsedResponse, ctx)
+      let output
+      if (parsedResponse) output = await wantedCommand.params.action(parsedResponse, ctx)
+      else output = await wantedCommand.params.action(resultsFound[1], ctx) // just give back the passed arg
 
       if (output) return '' + output
     } else {

--- a/src/lib/command.js
+++ b/src/lib/command.js
@@ -21,29 +21,30 @@ class Command {
   }
 
   async use (command, ctx = {}, op = true) {
-    let res = this.find(command)
-
-    if (res) {
-      let [com, pars] = res
-      if (com.params.onlyConsole && ctx.player) return 'This command is console only'
-      if (com.params.onlyPlayer && !ctx.player) throw new UserError('This command is player only')
-      if (com.params.op && !op) return 'You do not have permission to use this command'
-      const parse = com.params.parse
-      if (parse) {
-        if (typeof parse === 'function') {
-          pars = parse(pars, ctx)
-          if (pars === false) {
-            if (ctx.player) return com.params.usage ? 'Usage: ' + com.params.usage : 'Bad syntax'
-            else throw new UserError(com.params.usage ? 'Usage: ' + com.params.usage : 'Bad syntax')
+    const resultsFound = this.find(command)
+    let parsedResponse
+    if (resultsFound) {
+      const wantedCommand = resultsFound[0]
+      const passedArgs = resultsFound[1]
+      if (wantedCommand.params.onlyConsole && ctx.player) return 'This command is console only'
+      if (wantedCommand.params.onlyPlayer && !ctx.player) throw new UserError('This command is player only')
+      if (wantedCommand.params.op && !op) return 'You do not have permission to use this command'
+      const customArgsParser = wantedCommand.params.parse
+      if (customArgsParser) {
+        if (typeof customArgsParser === 'function') {
+          parsedResponse = customArgsParser(passedArgs, ctx)
+          if (parsedResponse === false) {
+            if (ctx.player) return wantedCommand.params.usage ? 'Usage: ' + wantedCommand.params.usage : 'Bad syntax'
+            else throw new UserError(wantedCommand.params.usage ? 'Usage: ' + wantedCommand.params.usage : 'Bad syntax')
           }
         } else {
-          pars = pars.match(parse)
+          parsedResponse = passedArgs.match(customArgsParser)
         }
       }
 
-      res = await com.params.action(pars, ctx)
+      const output = await wantedCommand.params.action(parsedResponse, ctx)
 
-      if (res) return '' + res
+      if (output) return '' + output
     } else {
       if (ctx.player) return 'Command not found'
       else throw new UserError('Command not found')


### PR DESCRIPTION
A lot of the variable names were 3 letter names that didn't have any comments, with this refactor, I added readability, and stopped mutating variables as much