### PR TITLE
Added jshintrc to suppress semicolons

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,7 @@
+{
+    "asi": true,
+    "esversion": 8,
+    "unstable": {
+        "bigint": true
+    }
+}


### PR DESCRIPTION
Exactly that. I added a `.jshintrc` initially to suppress missing semicolons, but also added statements for esversion and bigint.

Maybe the codebase should be refactored to include semicolons anyway? 🤔