### PR TITLE
Fix missing return for spawnObject

### DIFF
--- a/src/lib/plugins/spawn.js
+++ b/src/lib/plugins/spawn.js
@@ -48,6 +48,7 @@ module.exports.server = function (serv, options) {
     object.itemCount = itemCount
 
     object.updateAndSpawn()
+    return object
   }
 
   serv.spawnMob = (type, world, position, { pitch = 0, yaw = 0, headPitch = 0, velocity = new Vec3(0, 0, 0), metadata = [] } = {}) => {


### PR DESCRIPTION
Fixes a missing return for spawnObject, spawnMob returns a mob and spawnObject should therefore return the object