### PR TITLE
Create `empty` generation

### DIFF
--- a/src/lib/generations.js
+++ b/src/lib/generations.js
@@ -1,6 +1,7 @@
 module.exports = {
   grass_field: require('./worldGenerations/grass_field'),
   diamond_square: require('diamond-square'),
+  empty: require('./worldGenerations/empty'),
   superflat: require('./worldGenerations/superflat'),
   all_the_blocks: require('./worldGenerations/all_the_blocks'),
   nether: require('./worldGenerations/nether')

--- a/src/lib/worldGenerations/empty.js
+++ b/src/lib/worldGenerations/empty.js
@@ -1,0 +1,6 @@
+function generation ({ version }) {
+  const Chunk = require('prismarine-chunk')(version)
+  return () => new Chunk()
+}
+
+module.exports = generation


### PR DESCRIPTION
Sometimes you want to NOT generate chunks (eg. using pregenerated world, skyblock, etc), this PR adds `empty` generation.