### PR TITLE
Pin compromised color package

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "node": ">=8"
   },
   "dependencies": {
-    "colors": "^1.4.0",
+    "colors": "1.4.0",
     "diamond-square": "^1.2.0",
     "emit-then": "^2.0.0",
     "event-promise": "^0.0.1",


### PR DESCRIPTION
Package is in bad hands and should be replaced, but for now the old version are locked by npm so should be a temporary fix