### PR TITLE
Load plugins from the plugins folder outside of flying-squid

### DIFF
--- a/src/lib/plugins/external.js
+++ b/src/lib/plugins/external.js
@@ -24,11 +24,11 @@ module.exports.server = function (serv, settings) {
       require.resolve(p) // Check if it exists, if not do catch, otherwise jump to bottom
     } catch (err) {
       try { // Throw error if cannot find plugin
-        require.resolve('../../plugins/' + p)
+        require.resolve('../../../../../plugins/' + p)
       } catch (err) {
         throw new Error('Cannot find plugin "' + p + '"')
       }
-      serv.addPlugin(p, require('../../plugins/' + p), settings.plugins[p])
+      serv.addPlugin(p, require('../../../../../plugins/' + p), settings.plugins[p])
       return
     }
     serv.addPlugin(p, require(p), settings.plugins[p])


### PR DESCRIPTION
While trying to use flying-squid, I found that external plugins are resolved from either node_modules or a plugins folder inside flying-squid.
Here's the code as is currently in flying-squid, in src/lib/plugins/external.js
```js
try {
  require.resolve(p) // Check if it exists, if not do catch, otherwise jump to bottom
} catch (err) {
  try { // Throw error if cannot find plugin
    require.resolve('../../plugins/' + p)
  } catch (err) {
    throw new Error('Cannot find plugin "' + p + '"')
  }
  serv.addPlugin(p, require('../../plugins/' + p), settings.plugins[p])
  return
}
```
This code tries to resolve the plugin from node_modules, and if that fails, it tries to load it from src/plugins.
This makes developing a bit more difficult, because your plugins would have to be inside node_modules/flying-squid/src/plugins. This would require devs to commit node_modules, which is often included in their .gitignore file, or to make a fork of flying-squid with their plugins included in the fork.

Both of these options, in my opinion, aren't optimal.

With my pull request, external plugins are resolved first from node_modules as was the case before, and if that fails, flying-squid resolves them from outside of node_modules.

Here's an image of a directory tree with this setup.
![image](https://user-images.githubusercontent.com/72580505/151726153-fc1f9d7b-183b-4116-be67-33fe2323099c.png)

To load this ``example`` plugin in flying-squid, I would include it in the ``options`` like this:
```js
const mcServer = require('flying-squid')

mcServer.createMCServer({
  'motd': 'A Minecraft Server \nRunning flying-squid',
  'port': 25565,
  'max-players': 10,
  'online-mode': true,
  'logging': true,
  'gameMode': 1,
  'difficulty': 1,
  'worldFolder':'world',
  'generation': {
    'name': 'diamond_square',
    'options':{
      'worldHeight': 80
    }
  },
  'kickTimeout': 10000,
  'plugins': {
    'example': {}
  },
  'modpe': false,
  'view-distance': 10,
  'player-list-text': {
    'header':'Flying squid',
    'footer':'Test server'
  },
  'everybody-op': true,
  'max-entities': 100,
  'version': '1.16.1'
})
```
