### PR TITLE
Remove test server

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -23,7 +23,6 @@ Create Minecraft servers with a powerful, stable, and high level JavaScript API.
 
 ## Test server
 
-* [flying-squid.host](https://flying-squid.host) : hosted by @Saiv46
 
 ## Building / Running
 Before running or building it is recommended that you configure the server in `config/settings.json`


### PR DESCRIPTION
Due to US sanctions on Russian banks, it becomes impossible to pay for `flying-squid.host` domain renewal ~~and server hosting~~.

Domain will expire after 10th April. Test server is hosted on home network **as-is**.