### PR TITLE
Slot update notification

### DIFF
--- a/src/lib/plugins/placeBlock.js
+++ b/src/lib/plugins/placeBlock.js
@@ -153,7 +153,9 @@ module.exports.player = function (player, serv, { version }) {
     if (player.gameMode === 0) {
       heldItem.count--
       if (heldItem.count === 0) {
-        player.inventory.slots[36 + player.heldItemSlot] = null
+        player.inventory.updateSlot(36 + player.heldItemSlot, null)
+      } else {
+        player.inventory.updateSlot(36 + player.heldItemSlot, heldItem)
       }
     }
 


### PR DESCRIPTION
Fixes https://github.com/PrismarineJS/prismarine-web-client/issues/324

Flying Squid was directly updating player inventory in placeBlock.js, and was not sending notification for clients to detect.