### PR TITLE
Fixed two block placement bugs

### DIFF
--- a/src/lib/plugins/placeBlock.js
+++ b/src/lib/plugins/placeBlock.js
@@ -108,13 +108,15 @@ module.exports.player = function (player, serv, { version }) {
     const referencePosition = new Vec3(location.x, location.y, location.z)
     const block = await player.world.getBlock(referencePosition)
     block.position = referencePosition
+    block.direction = direction
     if (await serv.interactWithBlock({ block, player })) return
 
     const heldItem = player.inventory.slots[36 + player.heldItemSlot]
     if (!heldItem || direction === -1 || heldItem.type === -1) return
 
-    const directionVector = directionToVector[direction]
+    const directionVector = block.name === 'grass' ? new Vec3(0, 0, 0) : directionToVector[direction]
     const placedPosition = referencePosition.plus(directionVector)
+    if (placedPosition.equals(player.position.floored())) return
     const dx = player.position.x - (placedPosition.x + 0.5)
     const dz = player.position.z - (placedPosition.z + 0.5)
     const angle = Math.atan2(dx, -dz) * 180 / Math.PI + 180 // Convert to [0,360[


### PR DESCRIPTION
Fixed two bugs:

- A bug which allowed to place a block on the same position as the player 
- A bug which duplicated the block which was placed on a grass block

And add the direction on the block object to perform some actions with `serv.interactWithBlock`