### PR TITLE
Add a few flags to cli & disable `everybody-op` by default?

### DIFF
--- a/app.js
+++ b/app.js
@@ -16,7 +16,7 @@ const argv = require('yargs/yargs')(process.argv.slice(2))
   .option('log', {
     description: 'Enable logging: When true create log file in logs folder',
     type: 'boolean',
-    default: 'false'
+    default: 'true'
   })
   .option('op', {
     description: 'Useful for testing. When true gives everybody op (administrative permissions)',

--- a/app.js
+++ b/app.js
@@ -9,25 +9,38 @@ const argv = require('yargs/yargs')(process.argv.slice(2))
     default: './config',
     description: 'Configuration directory'
   })
+  .option('offline', {
+    type: 'boolean',
+    default: 'false'
+  })
+  .option('log', {
+    description: 'Enable logging: When true create log file in logs folder',
+    type: 'boolean',
+    default: 'false'
+  })
+  .option('op', {
+    description: 'Useful for testing. When true gives everybody op (administrative permissions)',
+    type: 'boolean',
+    default: 'false'
+  })
   .argv
 
 const mcServer = require('./')
 
-const defaultSettings = require('./config/default-settings')
+const defaultSettings = require('./config/default-settings.json')
 
 let settings
 
 try {
-  settings = require(`${argv.config}/settings`)
-
-  Object.keys(defaultSettings).forEach(settingKey => {
-    if (settings[settingKey] === undefined) {
-      settings[settingKey] = defaultSettings[settingKey]
-    }
-  })
+  settings = require(`${argv.config}/settings.json`)
 } catch (err) {
-  settings = defaultSettings
+  settings = {}
 }
+
+settings = Object.assign(settings, defaultSettings, settings)
+if (argv.offline) settings['online-mode'] = false
+if (argv.log) settings.logging = true
+if (argv.op) settings['everybody-op'] = true
 
 module.exports = mcServer.createMCServer(settings)
 

--- a/config/default-settings.json
+++ b/config/default-settings.json
@@ -23,7 +23,7 @@
     "header":{"text": "Flying squid"},
     "footer":{"text": "Test server"}
   },
-  "everybody-op":true,
+  "everybody-op": false,
   "max-entities":100,
   "version": "1.16.1"
 }


### PR DESCRIPTION
So its easier specify IMO commonly used options for testing without having to change config