### PR TITLE
Update Minecraft wiki links to new domain

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -512,7 +512,7 @@ Opt:
 
 Returns an array of entities that satisfies the given command selector string `str`, execution position `pos`, execution world `world`, and the ID of the entity that initiated the execution `ctxEntityId`.
 
-Valid selector string values are names of online players and [valid target selector variables](https://minecraft.fandom.com/wiki/Target_selectors#Target_selector_variables).
+Valid selector string values are names of online players and [valid target selector variables](https://minecraft.wiki/w/Target_selectors#Target_selector_variables).
 
 Setting `allowUser` to `true` (default value) enables players to be included in the returned array, disables otherwise.
 

--- a/src/lib/experience.js
+++ b/src/lib/experience.js
@@ -37,7 +37,7 @@ function getXpRequired (level, toLevel) {
 
 function getBaseXpFromLevel (level) {
   // The equations in this function are stupid and directly from the MC Wiki
-  // http://minecraft.gamepedia.com/Experience#Leveling_up
+  // http://minecraft.wiki/w/Experience#Leveling_up
   if (level <= 16) {
     return level * level + 6 * level
   } else if (level <= 31) {


### PR DESCRIPTION
The Minecraft Fandom wiki has been forked to a new domain: minecraft.wiki. Learn more here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates all URLs accordingly.