### PR TITLE
Updated the app.js code and README.md files so that PrismarineJS can be used under the latest NodeJS versions

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,3 +1,7 @@
+// global dependancies
+import {createRequire} from "node:module";
+const require = createRequire(import.meta.url);
+
 #!/usr/bin/env node
 // process.env.DEBUG = 'minecraft-protocol'
 Error.stackTraceLimit = 1000

--- a/docs/README.md
+++ b/docs/README.md
@@ -110,6 +110,9 @@ For development see the [API documentation](API.md), [CONTRIBUTE.md](CONTRIBUTE.
 flying-squid is also a server lib. Here is a basic example of usage:
 
 ```js
+import {createRequire} from "node:module";
+const require = createRequire(import.meta.url);
+
 const mcServer = require('flying-squid')
 
 mcServer.createMCServer({


### PR DESCRIPTION
Under the latest NodeJS versions if you want to use require you have to use :

import { createRequire } from "node:module"; // imports the createRequire function from the NodeJS CommonJS module handler
const require = createRequire(import.meta.url); // initializes the require function that NodeJS had under CommonJS